### PR TITLE
Remove content tests; remove alt test; fix message

### DIFF
--- a/cypress/integration/station1.spec.ts
+++ b/cypress/integration/station1.spec.ts
@@ -10,26 +10,20 @@ describe('Station1', function () {
     cy.get('html').should('be.visible')
   })
 
-  it('`<img>`タグに`src`と`alt`属性がある', function () {
-    cy.get('img').should('have.attr', 'alt')
+  it('`<img>`タグに`src`属性がある', function () {
     cy.get('img').should('have.attr', 'src', './assets/image/otya.jpg')
   })
 
   it('タイトルは`<p>`タグで，`id`および`class`属性をもたない', function () {
-    const titleTemplate = 'タイトル'
-
     cy.get('p').should(($p) => {
       const firstP = $p.first()
-      expect(firstP).to.contain(titleTemplate)
       expect(firstP[0].className).to.be.not.ok
       expect(firstP[0].id).to.be.not.ok
     })
   })
 
   // 一番目の<span>もしくは<p>の内容が`descriptionTemplate`と一致することをテストする
-  it('タイトルは`<span>`または`<p>`タグで，`id`および`class`属性をもたない', function () {
-    const descriptionTemplate = 'サブタイトル'
-
+  it('サブタイトルは`<span>`または`<p>`タグで，`id`および`class`属性をもたない', function () {
     cy.get('body')
       .then(($jQ) => {
         const spanTag = $jQ.find('span')
@@ -37,7 +31,6 @@ describe('Station1', function () {
       })
       .then(($target) => {
         expect($target).to.not.be.empty
-        expect($target).to.contain(descriptionTemplate)
         expect($target[0].className).to.be.not.ok
         expect($target[0].id).to.be.not.ok
       })


### PR DESCRIPTION
- Station 1の問題に`alt`の記述が無いためテストから削除
- タイトル・サブタイトルのテストから中身の検証を削除
- さいごのテストのラベルを修正