### PR TITLE
Allow CRLF end of line on Prettier

### DIFF
--- a/src/.prettierrc
+++ b/src/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "endOfLine":"auto"
 }


### PR DESCRIPTION
行端コードをautoにすることで，CRLFでもPrettierのテストがこけないように修正．