### PR TITLE
タブレットサイズで文字が小さくなっているかの判定の際にスマートフォンサイズでの文字サイズを判定しないようにした

### DIFF
--- a/cypress/integration/station9.spec.ts
+++ b/cypress/integration/station9.spec.ts
@@ -45,12 +45,6 @@ describe('Station9', () => {
       const fontSizeMedium = parseFloat(title.css('font-size'))
       expect(fontSizeMedium).lt(fontSize)
     })
-
-    cy.viewport(320, 1000)
-    cy.get('.card__description').then((title) => {
-      const fontSizeSmall = parseFloat(title.css('font-size'))
-      expect(fontSizeSmall).lt(fontSize)
-    })
   })
 
   it('スマートフォンで説明の文字が非表示になる', () => {


### PR DESCRIPTION
ステーション９の問題文では「スマートフォンで説明の文字が非表示になる」と書いてあるにもかかわらず、実際の判定が「スマートフォンで説明の文字が非表示になる」かつ、「スマートフォンで説明の文字が小さく表示されること」となっているため問題文にあわせて「スマートフォンで説明の文字が非表示になる」のみの判定に変えた