### PR TITLE
Feature/new station 18

### DIFF
--- a/.techtrain/manifests/railway.json
+++ b/.techtrain/manifests/railway.json
@@ -17,6 +17,7 @@
     "14": "station14.json",
     "15": "station15.json",
     "17": "station17.json",
+    "18": "station18.json",
     "21": "station21.json",
     "22": "station22.json",
     "23": "station23.json",

--- a/.techtrain/manifests/station18.json
+++ b/.techtrain/manifests/station18.json
@@ -1,0 +1,16 @@
+{
+  "name": "Station 18",
+  "id": 18,
+  "prepare": [
+    {
+      "command": "yarn lite-server",
+      "background": true
+    }
+  ],
+  "tests": [
+    {
+      "type": "cypress",
+      "specFile": "./cypress/integration/station18.spec.ts"
+    }
+  ]
+}

--- a/cypress/integration/station18.spec.ts
+++ b/cypress/integration/station18.spec.ts
@@ -10,8 +10,8 @@ describe('Station18', () => {
   it('開いたときにアニメーションが走る', () => {
     cy.get('#animation').then((animation) => {
       const duration = Number(animation.css('animation-duration').slice(0, -1))
-      expect(animation.css('animation-name')).not.to.be.eq('none')
       expect(duration).to.be.greaterThan(0)
+      expect(animation.css('animation-name')).not.to.be.eq('none')
     })
   })
 

--- a/cypress/integration/station18.spec.ts
+++ b/cypress/integration/station18.spec.ts
@@ -16,6 +16,9 @@ describe('Station18', () => {
   })
 
   it('アニメーションが終わった後も要素が表示されている', () => {
-    cy.get('#animation').should('have.css', 'animation-fill-mode', 'forwards')
+    cy.get('#animation').then((animation) => {
+      expect(animation.css('animation-fill-mode')).not.to.be.eq('none')
+      expect(animation.css('animation-fill-mode')).not.to.be.eq('backwards')
+    })
   })
 })

--- a/cypress/integration/station18.spec.ts
+++ b/cypress/integration/station18.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * # 「CSSアニメーションを作ろう！」 - CSS Animation
+ */
+
+describe('Station18', () => {
+  beforeEach(() => {
+    cy.visit('/station18.html')
+  })
+
+  it('開いたときにアニメーションが走る', () => {
+    cy.get('#animation').then((animation) => {
+      const duration = Number(animation.css('animation-duration').slice(0, -1))
+      expect(animation.css('animation-name')).not.to.be.eq('none')
+      expect(duration).to.be.greaterThan(0)
+    })
+  })
+
+  it('アニメーションが終わった後も要素が表示されている', () => {
+    cy.get('#animation').should('have.css', 'animation-fill-mode', 'forwards')
+  })
+})

--- a/src/station18.html
+++ b/src/station18.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./assets/css/station18.css" type="text/css" />
+    <title>Station 18</title>
+  </head>
+  <body>
+    <div id="animation">
+      <p>フェードイン</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
# CSSアニメーションを作ろう！ No.18
## 問題文
cssにはanimationというアニメーションを適用することができるプロパティがあります。  
このstationでは以下のサンプルコードを使ってCSSアニメーションでフェードインを実装しましょう！  
➀  
```css
#animation {
  animation: fade-in 3s;
  animation-fill-mode: forwards;
}
```
②  
```css
@keyframes fade-in {
  from {
    opacity: 0;
  }
  to {
    opacity: 1;
  }
}
```
【守るべき仕様】  
- ページを開いたときにアニメーションが実行される。
- `#animation`が付与されている要素をフェードインさせる。
- フェードイン後はそのまま表示させた状態にしておく。

## クリア基準
- 指定のタイミング（ページを開いたとき）にCSSアニメーションが走る。
- アニメーションが終わった後も要素が表示されている。