### PR TITLE
station20新規追加

### DIFF
--- a/.techtrain/manifests/railway.json
+++ b/.techtrain/manifests/railway.json
@@ -18,6 +18,7 @@
     "15": "station15.json",
     "16": "station16.json",
     "17": "station17.json",
+    "20": "station20.json",
     "21": "station21.json",
     "22": "station22.json",
     "23": "station23.json",

--- a/.techtrain/manifests/station20.json
+++ b/.techtrain/manifests/station20.json
@@ -1,0 +1,16 @@
+{
+  "name": "Station 20",
+  "id": 20,
+  "prepare": [
+    {
+      "command": "yarn lite-server",
+      "background": true
+    }
+  ],
+  "tests": [
+    {
+      "type": "cypress",
+      "specFile": "./cypress/integration/station20.spec.ts"
+    }
+  ]
+}

--- a/cypress/integration/station20.spec.ts
+++ b/cypress/integration/station20.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * # 「バリデーションをしよう！」 - Validation check
+ */
+
+describe('Station20', () => {
+  beforeEach(() => {
+    cy.visit('/station20.html')
+  })
+
+  it('メールアドレスの入力欄のtypeがemail,必須になっている', () => {
+    cy.get('form')
+      .find('input#email')
+      .should('have.attr', 'type', 'email')
+      .and('have.attr', 'required')
+  })
+
+  it('パスワードの入力欄のtypeがpassword, 必須, 6文字以上になっている', () => {
+    cy.get('form')
+      .find('input#password')
+      .should('have.attr', 'type', 'password')
+      .and('have.attr', 'minlength', '6')
+      .and('have.attr', 'required')
+  })
+
+  it('ニックネームの入力欄が20文字以下になっている', () => {
+    cy.get('form')
+      .find('input#nickname')
+      .should('have.attr', 'type', 'text')
+      .and('have.attr', 'maxlength', '20')
+  })
+})

--- a/src/station20.html
+++ b/src/station20.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <main>
+      <form action="" method="post">
+        <button type="submit">送信</button>
+      </form>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
# バリデーションをしよう！ No.20
## 問題文
皆さんが使うwebサービスでもアカウント登録の際にメールアドレスの欄にメールアドレスではないものを入れたり、パスワードの文字数が少なかったりするとそれを警告するメッセージが表示されますよね。今回はこれをHTMLで行いましょう。  
メールアドレス、パスワード、ニックネームを入力するフォームを作成してください。  
【守るべき仕様】  
- メールアドレス：必須、type=”email”、id=”email”
- パスワード：必須、６文字以上、type=”password”、id=”password”
- ニックネーム：任意、２０文字以下、 id=”nickname”

【コラム】  
このバリデーションチェックはフロントエンド側だけでなくサーバサイドでも行います。なぜ二重でチェック行うかといいますとフロントエンドとサーバサイドでバリデーションを行う理由が違うためです。  
フロントエンド：送信する前に入力値が間違っていることがわかるためユーザにやさしい。送信してから間違いを指摘されて入力し直すより送信する前に教えてくれたほうがいいですよね。  
サーバサイド：不正なデータからアプリやデータを守るため。悪意のある人物によってフロントエンドアプリを介さずに値が送られてくる可能性もあります（通常は送信元を制限しますが。。）。  

## クリア基準
- メールアドレスにrequired, type=”email”, id=”email”が付与されている。
- パスワードにrequired, type=”password”, minlength=6, id=”password”が付与されている。
- ニックネームにmaxlength=20, type=”text”, id=”nickname”が付与されている。requiredが付与されていない。