### PR TITLE
TTRN-744 : fix change case of "DOCTYPE"

### DIFF
--- a/src/station1.html
+++ b/src/station1.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8">

--- a/src/station11.html
+++ b/src/station11.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station12.html
+++ b/src/station12.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station13.html
+++ b/src/station13.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station14.html
+++ b/src/station14.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station15.html
+++ b/src/station15.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station2.html
+++ b/src/station2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
 <head>
 <meta charset="UTF-8" />

--- a/src/station3.html
+++ b/src/station3.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station4.html
+++ b/src/station4.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html>
+<!doctype html>

--- a/src/station5.html
+++ b/src/station5.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html>
+<!doctype html>

--- a/src/station6.html
+++ b/src/station6.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html>
+<!doctype html>

--- a/src/station7.html
+++ b/src/station7.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />

--- a/src/station8.html
+++ b/src/station8.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html>
+<!doctype html>

--- a/src/station9.html
+++ b/src/station9.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html>
+<!doctype html>


### PR DESCRIPTION
Prettier ^3.0.0 指定の場合、`<!DOCTYPE html>` ではなく、 `<!doctype html>`　 を要求するのでテンプレートを小文字に変更。

問題文のFigmaに掲載しているサンプルコードも変更。

↓ Figma は本番反映済
https://techtrain.dev/mypage/railway/1/station/2

<img width="1111" alt="image" src="https://github.com/TechBowl-japan/html-stations/assets/26006414/c46b64c0-bf66-40a9-a703-2eaec1f30907">
