### PR TITLE
【St1】fix st01.spec

### DIFF
--- a/playwright/station01.spec.ts
+++ b/playwright/station01.spec.ts
@@ -22,26 +22,25 @@ test('`<img>`タグに`src`属性がある', async ({ page }) => {
   )
 })
 
-test('タイトルは`<p>`タグで，`id`および`class`属性をもたない', async ({
+test('タイトルは`<p>`タグまたは`<span>`タグで，`id`および`class`属性をもたない', async ({
   page,
 }) => {
-  const p = await page.locator('p:nth-of-type(1)')
-
-  const className = await p.evaluate(node => node.className)
-  const id = await p.evaluate(node => node.id)
-
+  const body = await page.locator('body')
+  const p = await body.locator('p').first()
+  const span = await body.locator('span').first()
+  const target = (await p.count()) === 0 ? span : p
+  const className = await target.evaluate(node => node.className)
+  const id = await target.evaluate(node => node.id)
   expect(className).toBe('')
   expect(id).toBe('')
 })
 
-// 一番目の<span>もしくは<p>の内容が`descriptionTemplate`と一致することをテストする
-test('サブタイトルは`<span>`または`<p>`タグで，`id`および`class`属性をもたない', async ({
+test('サブタイトルは`<p>`タグで，`id`および`class`属性をもたない', async ({
   page,
 }) => {
-  const body = await page.locator('body')
-  const span = await body.locator('span')
-  const p = await body.locator('p').nth(1)
-  const target = (await span.count()) === 0 ? p : span
-  await expect(await target.evaluate(node => node.id)).toBe('')
-  await expect(await target.evaluate(node => node.className)).toBe('')
+  const p = await page.locator('p').nth(1)
+  const className = await p.evaluate(node => node.className)
+  const id = await p.evaluate(node => node.id)
+  expect(className).toBe('')
+  expect(id).toBe('')
 })

--- a/playwright/station01.spec.ts
+++ b/playwright/station01.spec.ts
@@ -7,40 +7,45 @@ test.beforeEach(async ({ page }) => {
   test.setTimeout(5000)
 })
 
-// FIXME: 機能していない
-test('`<html>`タグが存在する', async ({ page }) => {
-  // cy.get('html').should('be.visible')
+
+test('1. html タグが存在すること', async ({ page }) => {
   const html = await page.locator('html')
-  await expect(html).toBeVisible()
+  // htmlタグが存在することを確認
+  await expect(html).toHaveCount(1);
+  // htmlタグが正常に記述してあることを確認する代わりに、attributeを確認する
+  await expect(html).toHaveAttribute('lang', 'ja');
 })
 
-test('`<img>`タグに`src`属性がある', async ({ page }) => {
+
+test('2. img タグに src 属性が正しく使えていること', async ({ page }) => {
   const img = await page.locator('img')
   await expect(img).toHaveAttribute(
     'src',
     './assets/image/railway-thumbnail.png',
-  )
+  );
 })
 
-test('タイトルは`<p>`タグまたは`<span>`タグで，`id`および`class`属性をもたない', async ({
+
+test('3. `TechTrainの使い方` は p タグ、span タグを使用し、id や class を使っていないこと', async ({
   page,
 }) => {
-  const body = await page.locator('body')
-  const p = await body.locator('p').first()
-  const span = await body.locator('span').first()
-  const target = (await p.count()) === 0 ? span : p
-  const className = await target.evaluate(node => node.className)
-  const id = await target.evaluate(node => node.id)
-  expect(className).toBe('')
-  expect(id).toBe('')
+  const titleP = await page.locator('p').filter({ hasText: 'TechTrain' });
+  const titleSpan = await titleP.locator('span');
+
+  await expect(titleP).toHaveCount(1);
+  await expect(titleSpan).toHaveCount(1);
+
+  await expect(await titleP.evaluate(el => !el.hasAttribute('id') && !el.hasAttribute('class'))).toBeTruthy();
+  await expect(await titleSpan.evaluate(el => !el.hasAttribute('id') && !el.hasAttribute('class'))).toBeTruthy();
 })
 
-test('サブタイトルは`<p>`タグで，`id`および`class`属性をもたない', async ({
+
+test('4. `Suguru Ohki` は p タグを使用し、id や class を使っていないこと', async ({
   page,
 }) => {
-  const p = await page.locator('p').nth(1)
-  const className = await p.evaluate(node => node.className)
-  const id = await p.evaluate(node => node.id)
-  expect(className).toBe('')
-  expect(id).toBe('')
+  const subtitleP = await page.locator('p').filter({ hasText: 'Suguru' });
+
+  await expect(subtitleP).toHaveCount(1);
+
+  await expect(await subtitleP.evaluate(el => !el.hasAttribute('id') && !el.hasAttribute('class'))).toBeTruthy();
 })


### PR DESCRIPTION
figma の通りに TechTrain と TechBowl の文字を span を使用して太字にするとテストが通らないようになっていたので修正。