### PR TITLE
修正: Codespacesのイメージを軽量化

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:22-bullseye",
     "hostRequirements": {
       "cpus": 2
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
       "cpus": 2
     },
     "waitFor": "onCreateCommand",
-    "updateContentCommand": "yarn install && yarn playwright install",
+    "updateContentCommand": "yarn install && yarn playwright install && npx playwright install-deps",
     "postCreateCommand": "",
     "postAttachCommand": "",
     "customizations": {


### PR DESCRIPTION
Codespaces上で起動すると初期化時に容量不足でセットアップに失敗することがあった
<img width="824" alt="image" src="https://github.com/user-attachments/assets/a700e546-69e7-4809-9270-66ff9daae8ce" />

ので対策としてベースイメージを軽量化

- dev containersのベースイメージを軽量化
  - ベースイメージの変更に伴って依存関係を追加でインストールする必要が出たので初期化時のコマンドに追加

codespaces上で問題なく初期化が終了し、テストを実行できることを確認 
<img width="826" alt="image" src="https://github.com/user-attachments/assets/5f4eb544-8b60-42df-a8d3-a20a7c9b5c5b" />
